### PR TITLE
Add db.t2.medium to RDS cluster instance types

### DIFF
--- a/website/source/docs/providers/aws/r/rds_cluster_instance.html.markdown
+++ b/website/source/docs/providers/aws/r/rds_cluster_instance.html.markdown
@@ -53,6 +53,7 @@ string. If omitted, a unique identifier will be generated.
 * `instance_class` - (Required) The instance class to use. For details on CPU
 and memory, see [Scaling Aurora DB Instances][4]. Aurora currently
   supports the below instance classes.
+  - db.t2.medium
   - db.r3.large
   - db.r3.xlarge
   - db.r3.2xlarge


### PR DESCRIPTION
This PR updates the docs to reflect that **db.t2.medium** was added [as a valid Aurora cluster instance class](http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Aurora.CreateInstance.html#Aurora.CreateInstance.Console).